### PR TITLE
AUTOSCALE-270: Update pipeline annotations for new location

### DIFF
--- a/.tekton/cma-fbc-jkyros-quay-pull-request.yaml
+++ b/.tekton/cma-fbc-jkyros-quay-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-jkyros-quay-push.yaml
+++ b/.tekton/cma-fbc-jkyros-quay-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/cma-fbc-stage-4-12-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-12-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-stage-4-12-push.yaml
+++ b/.tekton/cma-fbc-stage-4-12-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/cma-fbc-stage-4-12.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/cma-fbc-stage-4-13-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-13-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-stage-4-13-push.yaml
+++ b/.tekton/cma-fbc-stage-4-13-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/cma-fbc-stage-4-13.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/cma-fbc-stage-4-14-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-14-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-stage-4-14-push.yaml
+++ b/.tekton/cma-fbc-stage-4-14-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/cma-fbc-stage-4-14.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/cma-fbc-stage-4-15-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-15-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-stage-4-15-push.yaml
+++ b/.tekton/cma-fbc-stage-4-15-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/cma-fbc-stage-4-15.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/cma-fbc-stage-4-16-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-16-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-stage-4-16-push.yaml
+++ b/.tekton/cma-fbc-stage-4-16-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/cma-fbc-stage-4-16.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/cma-fbc-stage-4-17-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-17-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-stage-4-17-push.yaml
+++ b/.tekton/cma-fbc-stage-4-17-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/cma-fbc-stage-4-17.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/cma-fbc-stage-4-18-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-18-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-stage-4-18-push.yaml
+++ b/.tekton/cma-fbc-stage-4-18-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/cma-fbc-stage-4-18.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/cma-fbc-stage-4-19-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-19-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-stage-4-19-push.yaml
+++ b/.tekton/cma-fbc-stage-4-19-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/cma-fbc-stage-4-19.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/cma-fbc-stage-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/cma-fbc-stage-push.yaml
+++ b/.tekton/cma-fbc-stage-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/cma-fbc-stage.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-jkyros-quay-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-jkyros-quay-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-jkyros-quay-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-jkyros-quay-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-bundle.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-fbc-4-12.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-fbc-4-13.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-fbc-4-14.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-fbc-4-15.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-fbc-4-16.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-fbc-4-17.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-fbc-4-18.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-fbc-4-19.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator-fbc.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"

--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/custom-metrics-autoscaler-operator.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"

--- a/.tekton/jkyros-keda-webhook-mig-pull-request.yaml
+++ b/.tekton/jkyros-keda-webhook-mig-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/jkyros-keda-webhook-mig-push.yaml
+++ b/.tekton/jkyros-keda-webhook-mig-push.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/keda-adapter.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/keda-operator.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: bundle-hack/imagerefs/keda-webhooks.pullspec
-    build.appstudio.openshift.io/repo: https://github.com/jkyros/custom-metrics-autoscaler-pipelines?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/custom-metrics-autoscaler-pipelines?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"


### PR DESCRIPTION
- This just updates the pipeline annotations to match the new location
 - I'm going to migrate using `metadata.annotations.build.appstudio.openshift.io/request: configure-pac-no-mr` so Konflux itself won't fix this(If I don't do that, and I let it send a new MR, we'll have to re-customize our pipelines which I really don't want to have to do). 