### PR TITLE
AUTOSCALE-270: Fix CMA operator pipeline push 

### DIFF
--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -414,7 +414,7 @@ spec:
       - name: image-digest
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT


### PR DESCRIPTION
- operator pipeline was messed up from a past manual migration, wouldn't run
- tests don't run the push pipeline, only the pull one, so you don't know until you push

At some point it's worth the science to see about havimg one shared pipeline def that pull/push both import (so aside from the on-cel expression we can guarantee they are the same). 