### PR TITLE
Remove broken clamav scan matrix

### DIFF
--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -461,11 +461,6 @@ spec:
         operator: in
         values:
         - 'false'
-      matrix:
-        params:
-        - name: image-arch
-          value:
-          - $(params.build-platforms)
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -459,11 +459,6 @@ spec:
         operator: in
         values:
         - 'false'
-      matrix:
-        params:
-        - name: image-arch
-          value:
-          - $(params.build-platforms)
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -461,11 +461,6 @@ spec:
         operator: in
         values:
         - 'false'
-      matrix:
-        params:
-        - name: image-arch
-          value:
-          - $(params.build-platforms)
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -459,11 +459,6 @@ spec:
         operator: in
         values:
         - 'false'
-      matrix:
-        params:
-        - name: image-arch
-          value:
-          - $(params.build-platforms)
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -461,11 +461,6 @@ spec:
         operator: in
         values:
         - 'false'
-      matrix:
-        params:
-        - name: image-arch
-          value:
-          - $(params.build-platforms)
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -459,11 +459,6 @@ spec:
         operator: in
         values:
         - 'false'
-      matrix:
-        params:
-        - name: image-arch
-          value:
-          - $(params.build-platforms)
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -461,11 +461,6 @@ spec:
         operator: in
         values:
         - 'false'
-      matrix:
-        params:
-        - name: image-arch
-          value:
-          - $(params.build-platforms)
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -463,11 +463,6 @@ spec:
         operator: in
         values:
         - 'false'
-      matrix:
-        params:
-        - name: image-arch
-          value:
-          - $(params.build-platforms)
     - name: apply-tags
       params:
       - name: IMAGE_URL


### PR DESCRIPTION
We're failing Conforma EC because clamav does not handle matrix well, see:
https://issues.redhat.com/browse/KONFLUX-9576

If we leave it in, we fail conforma because the image hashes it records are not the ones that conforma expects and we don't figure it out until we get to the EC stage, so this takes it out. 