### PR TITLE
Fix imageref nudges for bundle

### DIFF
--- a/bundle-hack/imagerefs/custom-metrics-autoscaler-operator-bundle.pullspec
+++ b/bundle-hack/imagerefs/custom-metrics-autoscaler-operator-bundle.pullspec
@@ -1,1 +1,1 @@
-quay.io/redhat-user-workloads/cma-podauto-tenant/custom-metrics-autoscaler-operator/custom-metrics-autoscaler-operator-bundle@sha256:623280ae8997a354e5fb3275afaf0d2bb5d260b5bae0c7f56b858b7dc33a1e48
+quay.io/redhat-user-workloads/cma-podauto-tenant/custom-metrics-autoscaler-operator-bundle@sha256:c25f45c04e085f39e7686cf28a6cb86fb777ea38ae44d9e898fceb8f6565ce5d


### PR DESCRIPTION
The bundle component was hosed, but when it got recreated, apparently we changed the naming scheme for imagerepositories so it's like it won't line up unless we force it. This just sets it to the proper image so hopefully nudges will wake up and start working.