### PR TITLE
AUTOSCALE-296: Add build bumpfile for force-triggering builds

### DIFF
--- a/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-pull-request.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "build-bump".pathChanged() || "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-pull-request.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/custom-metrics-autoscaler-operator-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-push.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "build-bump".pathChanged() || "custom-metrics-autoscaler-operator".pathChanged()  || "Dockerfile.cma-operator".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-push.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-adapter-pull-request.yaml
+++ b/.tekton/keda-adapter-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"  && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-pull-request.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"  && ( "build-bump".pathChanged() || "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-pull-request.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-adapter-push.yaml
+++ b/.tekton/keda-adapter-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-push.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "build-bump".pathChanged() || "kedacore-keda".pathChanged() || "Dockerfile.keda-adapter".pathChanged() || ".tekton/keda-adapter-push.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-operator-pull-request.yaml
+++ b/.tekton/keda-operator-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"  && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-pull-request.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"  && ( "build-bump".pathChanged() || "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-pull-request.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-operator-push.yaml
+++ b/.tekton/keda-operator-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-push.yaml".pathChanged()  || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "build-bump".pathChanged() || "kedacore-keda".pathChanged()  || "Dockerfile.keda-operator".pathChanged() || ".tekton/keda-operator-push.yaml".pathChanged()  || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-webhooks-pull-request.yaml
+++ b/.tekton/keda-webhooks-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ("kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-pull-request.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "build-bump".pathChanged() || "kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-pull-request.yaml".pathChanged() || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/.tekton/keda-webhooks-push.yaml
+++ b/.tekton/keda-webhooks-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-push.yaml".pathChanged()  || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "build-bump".pathChanged() || "kedacore-keda".pathChanged() || "Dockerfile.keda-webhooks".pathChanged() || ".tekton/keda-webhooks-push.yaml".pathChanged()  || "rpms.lock.yaml".pathChanged() || "tools/***".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: custom-metrics-autoscaler-operator

--- a/build-bump
+++ b/build-bump
@@ -1,0 +1,3 @@
+# any update to ths file will trigger all non-catalog component builds
+# this is necessary because sometines Konflux just decides to ignore a merge -- the webhook misses it or something
+bumps: 1 


### PR DESCRIPTION
This shouldn't be necessary, but Konflux is unrelable and having to put up a dummy PR to touch everything and force a rebuild is getting old.

This just adds a file that when poked will trigger all of the container builds, and adds it to the on-cel of all non-catalog pipelines.