### PR TITLE
Add on-cel expressions to FBC catalogs 

### DIFF
--- a/.tekton/cma-fbc-stage-4-12-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-12-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-12-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-12-pull-request.yaml".pathChanged() ||
         "catalogs/fbc-stage/Containerfile.catalog-4-12".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/cma-fbc-stage-4-12-push.yaml
+++ b/.tekton/cma-fbc-stage-4-12-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-12-push.yaml".pathChanged() ||
+        "catalogs/fbc-stage/Containerfile.catalog-4-12".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-12

--- a/.tekton/cma-fbc-stage-4-13-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-13-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-13-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-13-pull-request.yaml".pathChanged() ||
         "catalogs/fbc-stage/Containerfile.catalog-4-13".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/cma-fbc-stage-4-13-push.yaml
+++ b/.tekton/cma-fbc-stage-4-13-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-13-push.yaml".pathChanged() ||
+        "catalogs/fbc-stage/Containerfile.catalog-4-13".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-13

--- a/.tekton/cma-fbc-stage-4-14-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-14-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-14-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-14-pull-request.yaml".pathChanged() ||
         "catalogs/fbc-stage/Containerfile.catalog-4-14".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/cma-fbc-stage-4-14-push.yaml
+++ b/.tekton/cma-fbc-stage-4-14-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-14-push.yaml".pathChanged() ||
+        "catalogs/fbc-stage/Containerfile.catalog-4-14".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-14

--- a/.tekton/cma-fbc-stage-4-15-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-15-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-15-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-15-pull-request.yaml".pathChanged() ||
         "catalogs/fbc-stage/Containerfile.catalog-4-15".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/cma-fbc-stage-4-15-push.yaml
+++ b/.tekton/cma-fbc-stage-4-15-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-15-push.yaml".pathChanged() ||
+        "catalogs/fbc-stage/Containerfile.catalog-4-15".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-15

--- a/.tekton/cma-fbc-stage-4-16-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-16-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-16-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-16-pull-request.yaml".pathChanged() ||
         "catalogs/fbc-stage/Containerfile.catalog-4-16".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/cma-fbc-stage-4-16-push.yaml
+++ b/.tekton/cma-fbc-stage-4-16-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-16-push.yaml".pathChanged() ||
+        "catalogs/fbc-stage/Containerfile.catalog-4-16".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-16

--- a/.tekton/cma-fbc-stage-4-17-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-17-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-17-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-17-pull-request.yaml".pathChanged() ||
         "catalogs/fbc-stage/Containerfile.catalog-4-17".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/cma-fbc-stage-4-17-push.yaml
+++ b/.tekton/cma-fbc-stage-4-17-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-17-push.yaml".pathChanged() ||
+        "catalogs/fbc-stage/Containerfile.catalog-4-17".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-17

--- a/.tekton/cma-fbc-stage-4-18-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-18-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-18-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-18-pull-request.yaml".pathChanged() ||
         "catalogs/fbc-stage/Containerfile.catalog-4-18".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/cma-fbc-stage-4-18-push.yaml
+++ b/.tekton/cma-fbc-stage-4-18-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-18-push.yaml".pathChanged() ||
+        "catalogs/fbc-stage/Containerfile.catalog-4-18".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-18

--- a/.tekton/cma-fbc-stage-4-19-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-19-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-19-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-19-pull-request.yaml".pathChanged() ||
         "catalogs/fbc-stage/Containerfile.catalog-4-19".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/cma-fbc-stage-4-19-push.yaml
+++ b/.tekton/cma-fbc-stage-4-19-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-4-19-push.yaml".pathChanged() ||
+        "catalogs/fbc-stage/Containerfile.catalog-4-19".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-19

--- a/.tekton/cma-fbc-stage-push.yaml
+++ b/.tekton/cma-fbc-stage-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/catalog/***".pathChanged() || ".tekton/cma-fbc-stage-push.yaml".pathChanged() || "catalogs/fbc-stage/Containerfile.catalog".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-stage

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-12-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-12-pull-request.yaml".pathChanged() ||
         "catalogs/fbc/Containerfile.catalog-4-12".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-12-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-12-push.yaml".pathChanged() ||
+        "catalogs/fbc/Containerfile.catalog-4-12".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-4-12

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-13-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-13-pull-request.yaml".pathChanged() ||
         "catalogs/fbc/Containerfile.catalog-4-13".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-13-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-13-push.yaml".pathChanged() ||
+        "catalogs/fbc/Containerfile.catalog-4-13".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-4-13

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-14-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-14-pull-request.yaml".pathChanged() ||
         "catalogs/fbc/Containerfile.catalog-4-14".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-14-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-14-push.yaml".pathChanged() ||
+        "catalogs/fbc/Containerfile.catalog-4-14".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-4-14

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-15-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-15-pull-request.yaml".pathChanged() ||
         "catalogs/fbc/Containerfile.catalog-4-15".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-15-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-15-push.yaml".pathChanged() ||
+        "catalogs/fbc/Containerfile.catalog-4-15".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-4-15

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-16-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-16-pull-request.yaml".pathChanged() ||
         "catalogs/fbc/Containerfile.catalog-4-16".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-16-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-16-push.yaml".pathChanged() ||
+        "catalogs/fbc/Containerfile.catalog-4-16".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-4-16

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-17-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-17-pull-request.yaml".pathChanged() ||
         "catalogs/fbc/Containerfile.catalog-4-17".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-17-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-17-push.yaml".pathChanged() ||
+        "catalogs/fbc/Containerfile.catalog-4-17".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-4-17

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-18-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-18-pull-request.yaml".pathChanged() ||
         "catalogs/fbc/Containerfile.catalog-4-18".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-18-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-18-push.yaml".pathChanged() ||
+        "catalogs/fbc/Containerfile.catalog-4-18".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-4-18

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      event == "pull_request" && target_branch == "cma-konflux" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-19-pull-request.yaml".pathChanged() ||
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-19-pull-request.yaml".pathChanged() ||
         "catalogs/fbc/Containerfile.catalog-4-19".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-4-19-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-4-19-push.yaml".pathChanged() ||
+        "catalogs/fbc/Containerfile.catalog-4-19".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc-4-19

--- a/.tekton/custom-metrics-autoscaler-operator-fbc-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-fbc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "catalogs/fbc/catalog/***".pathChanged() || ".tekton/custom-metrics-autoscaler-operator-fbc-push.yaml".pathChanged() || "catalogs/fbc/Containerfile.catalog".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: cma-fbc


### PR DESCRIPTION
Every time *anything* merges it kicks off a thundering herd of fbc builds. This adds on-cel expressions to the fbc pipelines so they only trigger when catalog things change  or when they change. 