### PR TITLE
Fix broken rpm-signature-scan

### DIFF
--- a/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-pull-request.yaml
@@ -584,7 +584,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
+++ b/.tekton/custom-metrics-autoscaler-operator-bundle-push.yaml
@@ -582,7 +582,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
I had to re-onboard the bundle component and the new pipeline they gave me was referencing an untrusted task. They haven't fixed it yet, so I'm going to just flip it back to match the other pipelines. The untrusted task is resulting in us failing the EC.

With any luck this will also trigger a bundle build and snapshot that will ACTUALLY CONTAIN THE CORRECT IMAGES FOR ALL OF THE OPERANDS. This last time the bundle built with the old imageref for the keda-adapter due to some kind of race condition, and triggers are currently broken because of "Konflux reasons". 