### PR TITLE
AUTOSCALE-131: Update ocp repo to pull newer clients

### DIFF
--- a/repos/renovate_redhat.repo
+++ b/repos/renovate_redhat.repo
@@ -12,9 +12,9 @@ sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-4.20-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.20 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.20/os
+[rhocp-4.21-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.21 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.21/os
 enabled = 1
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -11,6 +11,7 @@ packages:
   - skopeo
   - tar
   - jq
+  - openshift-clients
 contentOrigin:
   repofiles:
     - repos/renovate_ubi.repo


### PR DESCRIPTION
Renovate doesn't know how to add the new OCP channels yet, so we still have to do it. This just bumps the OCP channels to 4.21 (I have already added them to the activation key so it will work -- but if you do this in the future you will need to make sure the activation key has equivalent access).