### PR TITLE
AUTOSCALE-131: Add gzip to rpm lockfile

### DIFF
--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -12,6 +12,7 @@ packages:
   - tar
   - jq
   - openshift-clients
+  - gzip
 contentOrigin:
   repofiles:
     - repos/renovate_ubi.repo


### PR DESCRIPTION
I don't know if gzip was in the image before but now it's not or what, but it's totally trying to install it now and it's not in the precache, so we need to add it.