### PR TITLE
AUTOSCALE-544: Add http-add on operands for build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "kedacore-keda"]
 	path = kedacore-keda
 	url = https://github.com/openshift/kedacore-keda
+[submodule "kedacore-http-add-on"]
+	path = kedacore-http-add-on
+	url = https://github.com/openshift/kedacore-http-add-on

--- a/Dockerfile.http-addon-interceptor
+++ b/Dockerfile.http-addon-interceptor
@@ -1,0 +1,62 @@
+# This needs to be fed into the build, otherwise something in Konflux
+# sets $VERSION to the go version and it looks like we're shipping KEDA 1.23
+# See: https://issues.redhat.com/browse/OCPBUGS-58129
+# Chore: this will get used in the release policy, so update this when our version we're releasing changes
+ARG CMA_VERSION=2.18.1
+# This needs to be updated on rebases, we should be able to get this out of the changelog
+# TODO(jkyros): add some test that verifies this matches the changelog
+ARG HTTP_ADD_ON_VERSION=0.12.1
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 as builder
+ARG CMA_VERSION
+
+LABEL stage=build
+ENV GO_COMPLIANCE_INFO=0
+ENV GO_COMPLIANCE_DEBUG=0
+ENV GOTOOLCHAIN=local
+
+ARG TARGETOS
+ARG TARGETARCH
+ENV ARCH=${TARGETARCH}
+
+COPY /kedacore-http-add-on/ /src/
+WORKDIR /src/
+
+RUN LOCALBIN=/src/bin GOFLAGS='-tags=strictfipsruntime' make CGO=1 VERSION=${CMA_VERSION} build-interceptor
+
+# MintMaker is not smart enough to figure out which "latest" you shipped,
+# so we need to keep the hash here and let MintMaker security update it. No, I don't like it either.
+# See: https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#enable-container-image-tag-versioning
+# FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829
+ARG CMA_VERSION
+ARG HTTP_ADD_ON_VERSION
+
+WORKDIR /
+RUN microdnf install -y tzdata && microdnf reinstall -y tzdata
+RUN test -f /usr/share/zoneinfo/America/New_York
+
+COPY --from=builder /src/bin/interceptor /usr/bin/http-add-on-interceptor
+
+RUN mkdir /licenses
+COPY --from=builder /src/LICENSE /licenses/
+
+USER nobody
+
+LABEL io.k8s.display-name="OpenShift KEDA HTTP Add-on Interceptor" \
+      io.k8s.description="This is a component of OpenShift which provides HTTP traffic interception and request buffering for the KEDA HTTP Add-on." \
+      com.redhat.component="keda-http-add-on-interceptor-container" \
+      name="custom-metrics-autoscaler/keda-http-add-on-interceptor-rhel9" \
+      cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.18::el9" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,keda,http-add-on" \
+      description="keda-http-add-on-interceptor-container" \
+      maintainer="AOS node team <aos-node@redhat.com>"
+
+# Chore: update this when openshift release changes
+LABEL com.redhat.openshift.versions="v4.20"
+
+LABEL version="${CMA_VERSION}"
+LABEL http_add_on_version="${HTTP_ADD_ON_VERSION}"
+LABEL release="1"
+
+ENTRYPOINT ["/usr/bin/http-add-on-interceptor"]

--- a/Dockerfile.http-addon-operator
+++ b/Dockerfile.http-addon-operator
@@ -1,0 +1,62 @@
+# This needs to be fed into the build, otherwise something in Konflux
+# sets $VERSION to the go version and it looks like we're shipping KEDA 1.23
+# See: https://issues.redhat.com/browse/OCPBUGS-58129
+# Chore: this will get used in the release policy, so update this when our version we're releasing changes
+ARG CMA_VERSION=2.18.1
+# This needs to be updated on rebases, we should be able to get this out of the changelog
+# TODO(jkyros): add some test that verifies this matches the changelog
+ARG HTTP_ADD_ON_VERSION=0.12.1
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 as builder
+ARG CMA_VERSION
+
+LABEL stage=build
+ENV GO_COMPLIANCE_INFO=0
+ENV GO_COMPLIANCE_DEBUG=0
+ENV GOTOOLCHAIN=local
+
+ARG TARGETOS
+ARG TARGETARCH
+ENV ARCH=${TARGETARCH}
+
+COPY /kedacore-http-add-on/ /src/
+WORKDIR /src/
+
+RUN LOCALBIN=/src/bin GOFLAGS='-tags=strictfipsruntime' make CGO=1 VERSION=${CMA_VERSION} build-operator
+
+# MintMaker is not smart enough to figure out which "latest" you shipped,
+# so we need to keep the hash here and let MintMaker security update it. No, I don't like it either.
+# See: https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#enable-container-image-tag-versioning
+# FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829
+ARG CMA_VERSION
+ARG HTTP_ADD_ON_VERSION
+
+WORKDIR /
+RUN microdnf install -y tzdata && microdnf reinstall -y tzdata
+RUN test -f /usr/share/zoneinfo/America/New_York
+
+COPY --from=builder /src/bin/operator /usr/bin/http-add-on-operator
+
+RUN mkdir /licenses
+COPY --from=builder /src/LICENSE /licenses/
+
+USER nobody
+
+LABEL io.k8s.display-name="OpenShift KEDA HTTP Add-on Operator" \
+      io.k8s.description="This is a component of OpenShift which provides HTTP-based autoscaling via the KEDA HTTP Add-on operator." \
+      com.redhat.component="keda-http-add-on-operator-container" \
+      name="custom-metrics-autoscaler/keda-http-add-on-operator-rhel9" \
+      cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.18::el9" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,keda,http-add-on" \
+      description="keda-http-add-on-operator-container" \
+      maintainer="AOS node team <aos-node@redhat.com>"
+
+# Chore: update this when openshift release changes
+LABEL com.redhat.openshift.versions="v4.20"
+
+LABEL version="${CMA_VERSION}"
+LABEL http_add_on_version="${HTTP_ADD_ON_VERSION}"
+LABEL release="1"
+
+ENTRYPOINT ["/usr/bin/http-add-on-operator"]

--- a/Dockerfile.http-addon-scaler
+++ b/Dockerfile.http-addon-scaler
@@ -1,0 +1,62 @@
+# This needs to be fed into the build, otherwise something in Konflux
+# sets $VERSION to the go version and it looks like we're shipping KEDA 1.23
+# See: https://issues.redhat.com/browse/OCPBUGS-58129
+# Chore: this will get used in the release policy, so update this when our version we're releasing changes
+ARG CMA_VERSION=2.18.1
+# This needs to be updated on rebases, we should be able to get this out of the changelog
+# TODO(jkyros): add some test that verifies this matches the changelog
+ARG HTTP_ADD_ON_VERSION=0.12.1
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 as builder
+ARG CMA_VERSION
+
+LABEL stage=build
+ENV GO_COMPLIANCE_INFO=0
+ENV GO_COMPLIANCE_DEBUG=0
+ENV GOTOOLCHAIN=local
+
+ARG TARGETOS
+ARG TARGETARCH
+ENV ARCH=${TARGETARCH}
+
+COPY /kedacore-http-add-on/ /src/
+WORKDIR /src/
+
+RUN LOCALBIN=/src/bin GOFLAGS='-tags=strictfipsruntime' make CGO=1 VERSION=${CMA_VERSION} build-scaler
+
+# MintMaker is not smart enough to figure out which "latest" you shipped,
+# so we need to keep the hash here and let MintMaker security update it. No, I don't like it either.
+# See: https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#enable-container-image-tag-versioning
+# FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:bb08f2300cb8d12a7eb91dddf28ea63692b3ec99e7f0fa71a1b300f2756ea829
+ARG CMA_VERSION
+ARG HTTP_ADD_ON_VERSION
+
+WORKDIR /
+RUN microdnf install -y tzdata && microdnf reinstall -y tzdata
+RUN test -f /usr/share/zoneinfo/America/New_York
+
+COPY --from=builder /src/bin/scaler /usr/bin/http-add-on-scaler
+
+RUN mkdir /licenses
+COPY --from=builder /src/LICENSE /licenses/
+
+USER nobody
+
+LABEL io.k8s.display-name="OpenShift KEDA HTTP Add-on Scaler" \
+      io.k8s.description="This is a component of OpenShift which provides the external scaler gRPC service for the KEDA HTTP Add-on." \
+      com.redhat.component="keda-http-add-on-scaler-container" \
+      name="custom-metrics-autoscaler/keda-http-add-on-scaler-rhel9" \
+      cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.18::el9" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,keda,http-add-on" \
+      description="keda-http-add-on-scaler-container" \
+      maintainer="AOS node team <aos-node@redhat.com>"
+
+# Chore: update this when openshift release changes
+LABEL com.redhat.openshift.versions="v4.20"
+
+LABEL version="${CMA_VERSION}"
+LABEL http_add_on_version="${HTTP_ADD_ON_VERSION}"
+LABEL release="1"
+
+ENTRYPOINT ["/usr/bin/http-add-on-scaler"]


### PR DESCRIPTION
We want to ship the http add on with CMA as an additional feature (not a separate product). It comes out of a different repo so we have to add a new submodule for it, etc.

After this is in, I'll set up the pipeline for it (and hopefully the pipeline init will successfully build, but probably not :stuck_out_tongue: ) 