### PR TITLE
AUTOSCALE-625: Use golang builder temporarily for KEDA

### DIFF
--- a/Dockerfile.keda-adapter
+++ b/Dockerfile.keda-adapter
@@ -5,7 +5,11 @@
 ARG CMA_VERSION=2.18.1
 #TODO(jkyros): There is something wrong with repo cert trust between the published RPM repos and the builder
 # It's a builder though, so I dunno if I really care 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+#FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+# TODO(jkyros): we need to switch back to brew once we _finally_ get a builder, this is temporarly
+# until openshift catches up 
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26-1779719578 as builder
+USER 0:0
 ARG CMA_VERSION
 
 #FROM registry.redhat.io/ubi9/go-toolset as builder

--- a/Dockerfile.keda-operator
+++ b/Dockerfile.keda-operator
@@ -5,7 +5,11 @@
 ARG CMA_VERSION=2.18.1
 #TODO(jkyros): There is something wrong with repo cert trust between the published RPM repos and the builder
 # It's a builder though, so I dunno if I really care 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+#FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+# TODO(jkyros): we need to switch back to brew once we _finally_ get a builder, this is temporarly
+# until openshift catches up 
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26-1779719578 as builder
+USER 0:0
 ARG CMA_VERSION 
 
 #FROM registry.redhat.io/ubi9/go-toolset as builder

--- a/Dockerfile.keda-webhooks
+++ b/Dockerfile.keda-webhooks
@@ -5,7 +5,11 @@
 ARG CMA_VERSION=2.18.1
 #TODO(jkyros): There is something wrong with repo cert trust between the published RPM repos and the builder
 # It's a builder though, so I dunno if I really care 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+#FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+# TODO(jkyros): we need to switch back to brew once we _finally_ get a builder, this is temporarly
+# until openshift catches up 
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26-1779719578 as builder
+USER 0:0
 ARG CMA_VERSION
 
 #FROM registry.redhat.io/ubi9/go-toolset as builder


### PR DESCRIPTION
We still don't have a go 1.26 builder for openshift, so I'm going to use the "upstream" go builder for just this cycle so we're not stuck waiting.