### PR TITLE
AUTOSCALE-625: Fix 4.22 not being in brew

### DIFF
--- a/catalogs/fbc-stage/Containerfile.catalog-4-22
+++ b/catalogs/fbc-stage/Containerfile.catalog-4-22
@@ -1,5 +1,7 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22
+#FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22
+# TODO(jkyros): 4.22 is not in brew for vague reasons, but it is in normal registry
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/catalogs/fbc/Containerfile.catalog-4-22
+++ b/catalogs/fbc/Containerfile.catalog-4-22
@@ -1,5 +1,7 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22
+#FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22
+# TODO(jkyros): 4.22 is not in brew for vague reasons, but it is in normal registry
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]


### PR DESCRIPTION
Apparently 4.22 is not in brew because ART reasons, we apparently release it to the registry when we branch cut now? So we can reference it there? 