### PR TITLE
AUTOSCALE-625: Fix 4.22 pipeline context and cel expressions

### DIFF
--- a/.tekton/cma-fbc-4-21-pull-request.yaml
+++ b/.tekton/cma-fbc-4-21-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "catalogs/fbc-stage/***".pathChanged() || ".tekton/cma-fbc-4-21-pull-request.yaml".pathChanged()
+      == "main" && ( "catalogs/fbc/***".pathChanged() || ".tekton/cma-fbc-4-21-pull-request.yaml".pathChanged()
       || "catalogs/fbc/Containerfile.catalog-4-21".pathChanged() )
   creationTimestamp: null
   labels:

--- a/.tekton/cma-fbc-4-21-push.yaml
+++ b/.tekton/cma-fbc-4-21-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "catalogs/fbc-stage/***".pathChanged() || ".tekton/cma-fbc-4-21-push.yaml".pathChanged()
+      == "main" && ( "catalogs/fbc/***".pathChanged() || ".tekton/cma-fbc-4-21-push.yaml".pathChanged()
       || "catalogs/fbc/Containerfile.catalog-4-21".pathChanged() )
   creationTimestamp: null
   labels:

--- a/.tekton/cma-fbc-4-22-pull-request.yaml
+++ b/.tekton/cma-fbc-4-22-pull-request.yaml
@@ -8,8 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc/***".pathChanged() || ".tekton/cma-fbc-4-22-pull-request.yaml".pathChanged()
+        || "catalogs/fbc/Containerfile.catalog-4-22".pathChanged() )
   labels:
     appstudio.openshift.io/application: cma-fbc-4-22
     appstudio.openshift.io/component: cma-fbc-4-22
@@ -31,6 +32,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: catalogs/fbc/Containerfile.catalog-4-22
+  - name: path-context
+    value: catalogs/fbc
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/end-to-end/building-olm/#building-the-file-based-catalog).

--- a/.tekton/cma-fbc-4-22-push.yaml
+++ b/.tekton/cma-fbc-4-22-push.yaml
@@ -7,8 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc/***".pathChanged() || ".tekton/cma-fbc-4-22-push.yaml".pathChanged()
+        || "catalogs/fbc/Containerfile.catalog-4-22".pathChanged() )
   labels:
     appstudio.openshift.io/application: cma-fbc-4-22
     appstudio.openshift.io/component: cma-fbc-4-22
@@ -28,6 +29,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: catalogs/fbc/Containerfile.catalog-4-22
+  - name: path-context
+    value: catalogs/fbc
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/end-to-end/building-olm/#building-the-file-based-catalog).

--- a/.tekton/cma-fbc-stage-4-22-pull-request.yaml
+++ b/.tekton/cma-fbc-stage-4-22-pull-request.yaml
@@ -8,8 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "pull_request" && target_branch == "main" && ( "catalogs/fbc-stage/***".pathChanged() || ".tekton/cma-fbc-stage-4-22-pull-request.yaml".pathChanged()
+        || "catalogs/fbc-stage/Containerfile.catalog-4-22".pathChanged() )
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-22
     appstudio.openshift.io/component: cma-fbc-stage-4-22
@@ -31,6 +32,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: catalogs/fbc-stage/Containerfile.catalog-4-22
+  - name: path-context
+    value: catalogs/fbc-stage
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/end-to-end/building-olm/#building-the-file-based-catalog).

--- a/.tekton/cma-fbc-stage-4-22-push.yaml
+++ b/.tekton/cma-fbc-stage-4-22-push.yaml
@@ -7,8 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      event == "push" && target_branch == "main" && ( "catalogs/fbc-stage/***".pathChanged() || ".tekton/cma-fbc-stage-4-22-push.yaml".pathChanged()
+        || "catalogs/fbc-stage/Containerfile.catalog-4-22".pathChanged() )
   labels:
     appstudio.openshift.io/application: cma-fbc-stage-4-22
     appstudio.openshift.io/component: cma-fbc-stage-4-22
@@ -28,6 +29,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: catalogs/fbc-stage/Containerfile.catalog-4-22
+  - name: path-context
+    value: catalogs/fbc-stage
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/end-to-end/building-olm/#building-the-file-based-catalog).


### PR DESCRIPTION
The PaC pipeline proposal didn't specify the context for the dockerfiles so we had to do that here, and then we fixed some of the less restrictive on-cel expressions that we had from 4.21 