### PR TITLE
AUTOSCALE-625: Fix add-on labels to reference CMA instead of keda

### DIFF
--- a/Dockerfile.http-addon-interceptor
+++ b/Dockerfile.http-addon-interceptor
@@ -45,7 +45,7 @@ USER nobody
 LABEL io.k8s.display-name="OpenShift KEDA HTTP Add-on Interceptor" \
       io.k8s.description="This is a component of OpenShift which provides HTTP traffic interception and request buffering for the KEDA HTTP Add-on." \
       com.redhat.component="keda-http-add-on-interceptor-container" \
-      name="custom-metrics-autoscaler/keda-http-add-on-interceptor-rhel9" \
+      name="custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-interceptor-rhel9" \
       cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.19::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,keda,http-add-on" \

--- a/Dockerfile.http-addon-operator
+++ b/Dockerfile.http-addon-operator
@@ -45,7 +45,7 @@ USER nobody
 LABEL io.k8s.display-name="OpenShift KEDA HTTP Add-on Operator" \
       io.k8s.description="This is a component of OpenShift which provides HTTP-based autoscaling via the KEDA HTTP Add-on operator." \
       com.redhat.component="keda-http-add-on-operator-container" \
-      name="custom-metrics-autoscaler/keda-http-add-on-operator-rhel9" \
+      name="custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-operator-rhel9" \
       cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.19::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,keda,http-add-on" \

--- a/Dockerfile.http-addon-scaler
+++ b/Dockerfile.http-addon-scaler
@@ -45,7 +45,7 @@ USER nobody
 LABEL io.k8s.display-name="OpenShift KEDA HTTP Add-on Scaler" \
       io.k8s.description="This is a component of OpenShift which provides the external scaler gRPC service for the KEDA HTTP Add-on." \
       com.redhat.component="keda-http-add-on-scaler-container" \
-      name="custom-metrics-autoscaler/keda-http-add-on-scaler-rhel9" \
+      name="custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-scaler-rhel9" \
       cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.19::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,keda,http-add-on" \


### PR DESCRIPTION
Enterprise Contract is enforcing matching labels, so these needed to get fixed, and we can rebuild. 