### PR TITLE
AUTOSCALE-624: Add http-addon images to mirror set

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -23,3 +23,12 @@ spec:
   - mirrors:
     - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9
     source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9
+  - mirrors:
+    - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-operator-rhel9
+    source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-operator-rhel9
+  - mirrors:
+    - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-interceptor-rhel9
+    source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-interceptor-rhel9
+  - mirrors:
+    - registry.stage.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-scaler-rhel9
+    source: registry.redhat.io/custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-scaler-rhel9


### PR DESCRIPTION
FBC bundles try to look up the images to assess them and fail because they haven't been shipped yet. If we add them to the image map that will fix this. 