### PR TITLE
Fix http add-on labels and generation

### DIFF
--- a/Dockerfile.http-addon-interceptor
+++ b/Dockerfile.http-addon-interceptor
@@ -44,12 +44,12 @@ USER nobody
 
 LABEL io.k8s.display-name="OpenShift KEDA HTTP Add-on Interceptor" \
       io.k8s.description="This is a component of OpenShift which provides HTTP traffic interception and request buffering for the KEDA HTTP Add-on." \
-      com.redhat.component="keda-http-add-on-interceptor-container" \
+      com.redhat.component="custom-metrics-autoscaler-http-add-on-interceptor-container" \
       name="custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-interceptor-rhel9" \
       cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.19::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,keda,http-add-on" \
-      description="keda-http-add-on-interceptor-container" \
+      description="custom-metrics-autoscaler-http-add-on-interceptor-container" \
       maintainer="AOS node team <aos-node@redhat.com>"
 
 # Chore: update this when openshift release changes

--- a/Dockerfile.http-addon-operator
+++ b/Dockerfile.http-addon-operator
@@ -44,12 +44,12 @@ USER nobody
 
 LABEL io.k8s.display-name="OpenShift KEDA HTTP Add-on Operator" \
       io.k8s.description="This is a component of OpenShift which provides HTTP-based autoscaling via the KEDA HTTP Add-on operator." \
-      com.redhat.component="keda-http-add-on-operator-container" \
+      com.redhat.component="custom-metrics-autoscaler-http-add-on-operator-container" \
       name="custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-operator-rhel9" \
       cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.19::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,keda,http-add-on" \
-      description="keda-http-add-on-operator-container" \
+      description="custom-metrics-autoscaler-http-add-on-operator-container" \
       maintainer="AOS node team <aos-node@redhat.com>"
 
 # Chore: update this when openshift release changes

--- a/Dockerfile.http-addon-scaler
+++ b/Dockerfile.http-addon-scaler
@@ -44,12 +44,12 @@ USER nobody
 
 LABEL io.k8s.display-name="OpenShift KEDA HTTP Add-on Scaler" \
       io.k8s.description="This is a component of OpenShift which provides the external scaler gRPC service for the KEDA HTTP Add-on." \
-      com.redhat.component="keda-http-add-on-scaler-container" \
+      com.redhat.component="custom-metrics-autoscaler-http-add-on-scaler-container" \
       name="custom-metrics-autoscaler/custom-metrics-autoscaler-http-add-on-scaler-rhel9" \
       cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.19::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,keda,http-add-on" \
-      description="keda-http-add-on-scaler-container" \
+      description="custom-metrics-autoscaler-http-add-on-scaler-container" \
       maintainer="AOS node team <aos-node@redhat.com>"
 
 # Chore: update this when openshift release changes

--- a/bundle-hack/update_bundle.sh
+++ b/bundle-hack/update_bundle.sh
@@ -61,9 +61,9 @@ else
    KEDA_OPERATOR_PULLSPEC=$( echo $KEDA_OPERATOR_PULLSPEC | sed -e "s#$APP_PREFIX/keda-operator#$REWRITE_PREFIX/custom-metrics-autoscaler-$OSVER#" )
    KEDA_WEBHOOK_PULLSPEC=$( echo $KEDA_WEBHOOK_PULLSPEC | sed -e "s#$APP_PREFIX/keda-webhooks#$REWRITE_PREFIX/custom-metrics-autoscaler-admission-webhooks-$OSVER#" )
    KEDA_ADAPTER_PULLSPEC=$( echo $KEDA_ADAPTER_PULLSPEC | sed -e "s#$APP_PREFIX/keda-adapter#$REWRITE_PREFIX/custom-metrics-autoscaler-adapter-$OSVER#" )
-   HTTP_ADDON_INTERCEPTOR_PULLSPEC=$( echo $HTTP_ADDON_INTERCEPTOR_PULLSPEC | sed -e "s#$APP_BASE/http-addon-interceptor#$REWRITE_PREFIX/keda-http-add-on-interceptor-$OSVER#" )
-   HTTP_ADDON_OPERATOR_PULLSPEC=$( echo $HTTP_ADDON_OPERATOR_PULLSPEC | sed -e "s#$APP_BASE/http-addon-operator#$REWRITE_PREFIX/keda-http-add-on-operator-$OSVER#" )
-   HTTP_ADDON_SCALER_PULLSPEC=$( echo $HTTP_ADDON_SCALER_PULLSPEC | sed -e "s#$APP_BASE/http-addon-scaler#$REWRITE_PREFIX/keda-http-add-on-scaler-$OSVER#" )
+   HTTP_ADDON_INTERCEPTOR_PULLSPEC=$( echo $HTTP_ADDON_INTERCEPTOR_PULLSPEC | sed -e "s#$APP_BASE/http-addon-interceptor#$REWRITE_PREFIX/custom-metrics-autoscaler-http-add-on-interceptor-$OSVER#" )
+   HTTP_ADDON_OPERATOR_PULLSPEC=$( echo $HTTP_ADDON_OPERATOR_PULLSPEC | sed -e "s#$APP_BASE/http-addon-operator#$REWRITE_PREFIX/custom-metrics-autoscaler-http-add-on-operator-$OSVER#" )
+   HTTP_ADDON_SCALER_PULLSPEC=$( echo $HTTP_ADDON_SCALER_PULLSPEC | sed -e "s#$APP_BASE/http-addon-scaler#$REWRITE_PREFIX/custom-metrics-autoscaler-http-add-on-scaler-$OSVER#" )
 fi
 
 # Since we moved the versioned manifest to /manifests, we can just use it from there


### PR DESCRIPTION
We originally called this the keda http addon operator but the repos, etc we called it the custom-metrics-autoscaler-http-add-on-* so we need to update the rest of these references. I didn't catch it until the catalog tried to scan the images and couldn't find them.