### PR TITLE
NO-JIRA: Update 5.0 fbcs to point to prod registry

### DIFF
--- a/catalogs/fbc-stage/Containerfile.catalog-5-0
+++ b/catalogs/fbc-stage/Containerfile.catalog-5-0
@@ -1,5 +1,8 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v5.0
+#FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v5.0
+# 5.0 is weird, they released it to registry, but not to brew 
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v5.0
+
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/catalogs/fbc/Containerfile.catalog-5-0
+++ b/catalogs/fbc/Containerfile.catalog-5-0
@@ -1,5 +1,7 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v5.0
+#FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v5.0
+# 5.0 is weird, they released it to registry, but not to brew 
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v5.0
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]


### PR DESCRIPTION
So it looks like the 5.0 image never made it into brew because 5.0 is weird, but it is in the prod registry, so we're going to try building with that. 